### PR TITLE
ISSUE-043 Server: Huge commit that restructures how classrooms are ha…

### DIFF
--- a/server/database/datamodel.graphql
+++ b/server/database/datamodel.graphql
@@ -9,8 +9,8 @@ type User {
   type: Int!
   status: Int!
   flags: Int!
-  classrooms: [Classroom!]! @relation(name: "UserToClassroom")
   enrollment: Enrollment @relation(name: "UserToEnrollment")
+  classroomsTeaching: [Classroom!]! @relation(name: "UserToClassroom")
 }
 
 # This is a structure that will allow teacher(s) to connect to their students and students to
@@ -22,7 +22,8 @@ type Classroom {
   status: Int!
   flags: Int!
   notes: String!
-  users: [User!]! @relation(name: "UserToClassroom")
+  studentCourses: [Course!]! @relation(name: "CourseToClassroom")
+  teachers: [User!]! @relation(name: "UserToClassroom")
 }
 
 # A student has a single enrollment row. An enrollment is their place in the school.
@@ -42,6 +43,7 @@ type Course {
   status: Int!
   flags: Int!
   parent: Enrollment! @relation(name: "EnrollmentToCourse")
+  classrooms: [Classroom!]! @relation(name: "CourseToClassroom")
   masteries: [Mastery!]! @relation(name: "CourseToMastery")
   surveys: [Survey!]! @relation(name: "CourseToSurvey")
 }

--- a/server/database/dataseed.graphql
+++ b/server/database/dataseed.graphql
@@ -465,7 +465,7 @@ mutation {
     type: 0
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -478,7 +478,7 @@ mutation {
     type: 0
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -491,7 +491,7 @@ mutation {
     type: 0
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -505,7 +505,7 @@ mutation {
     type: 1
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -519,7 +519,7 @@ mutation {
     type: 1
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -533,7 +533,7 @@ mutation {
     type: 1
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -546,7 +546,7 @@ mutation {
     type: 2
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id
@@ -559,7 +559,7 @@ mutation {
     type: 3
     status: 0
     flags: 0
-    classrooms: null
+    classroomsTeaching: null
     enrollment: null
   }) {
     id

--- a/server/src/generated/prisma.graphql
+++ b/server/src/generated/prisma.graphql
@@ -1,5 +1,5 @@
 # source: http://self:4466/server/dev
-# timestamp: Wed Jun 06 2018 18:49:58 GMT-0700 (PDT)
+# timestamp: Thu Jun 07 2018 15:37:47 GMT-0700 (PDT)
 
 type AggregateClassroom {
   count: Int!
@@ -49,7 +49,8 @@ type Classroom implements Node {
   status: Int!
   flags: Int!
   notes: String!
-  users(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
+  studentCourses(where: CourseWhereInput, orderBy: CourseOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Course!]
+  teachers(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
 }
 
 """A connection to a list of items."""
@@ -68,20 +69,36 @@ input ClassroomCreateInput {
   status: Int!
   flags: Int!
   notes: String!
-  users: UserCreateManyWithoutClassroomsInput
+  studentCourses: CourseCreateManyWithoutClassroomsInput
+  teachers: UserCreateManyWithoutClassroomsTeachingInput
 }
 
-input ClassroomCreateManyWithoutUsersInput {
-  create: [ClassroomCreateWithoutUsersInput!]
+input ClassroomCreateManyWithoutStudentCoursesInput {
+  create: [ClassroomCreateWithoutStudentCoursesInput!]
   connect: [ClassroomWhereUniqueInput!]
 }
 
-input ClassroomCreateWithoutUsersInput {
+input ClassroomCreateManyWithoutTeachersInput {
+  create: [ClassroomCreateWithoutTeachersInput!]
+  connect: [ClassroomWhereUniqueInput!]
+}
+
+input ClassroomCreateWithoutStudentCoursesInput {
   name: String!
   description: String!
   status: Int!
   flags: Int!
   notes: String!
+  teachers: UserCreateManyWithoutClassroomsTeachingInput
+}
+
+input ClassroomCreateWithoutTeachersInput {
+  name: String!
+  description: String!
+  status: Int!
+  flags: Int!
+  notes: String!
+  studentCourses: CourseCreateManyWithoutClassroomsInput
 }
 
 """An edge in a connection."""
@@ -166,35 +183,66 @@ input ClassroomUpdateInput {
   status: Int
   flags: Int
   notes: String
-  users: UserUpdateManyWithoutClassroomsInput
+  studentCourses: CourseUpdateManyWithoutClassroomsInput
+  teachers: UserUpdateManyWithoutClassroomsTeachingInput
 }
 
-input ClassroomUpdateManyWithoutUsersInput {
-  create: [ClassroomCreateWithoutUsersInput!]
+input ClassroomUpdateManyWithoutStudentCoursesInput {
+  create: [ClassroomCreateWithoutStudentCoursesInput!]
   connect: [ClassroomWhereUniqueInput!]
   disconnect: [ClassroomWhereUniqueInput!]
   delete: [ClassroomWhereUniqueInput!]
-  update: [ClassroomUpdateWithWhereUniqueWithoutUsersInput!]
-  upsert: [ClassroomUpsertWithWhereUniqueWithoutUsersInput!]
+  update: [ClassroomUpdateWithWhereUniqueWithoutStudentCoursesInput!]
+  upsert: [ClassroomUpsertWithWhereUniqueWithoutStudentCoursesInput!]
 }
 
-input ClassroomUpdateWithoutUsersDataInput {
+input ClassroomUpdateManyWithoutTeachersInput {
+  create: [ClassroomCreateWithoutTeachersInput!]
+  connect: [ClassroomWhereUniqueInput!]
+  disconnect: [ClassroomWhereUniqueInput!]
+  delete: [ClassroomWhereUniqueInput!]
+  update: [ClassroomUpdateWithWhereUniqueWithoutTeachersInput!]
+  upsert: [ClassroomUpsertWithWhereUniqueWithoutTeachersInput!]
+}
+
+input ClassroomUpdateWithoutStudentCoursesDataInput {
   name: String
   description: String
   status: Int
   flags: Int
   notes: String
+  teachers: UserUpdateManyWithoutClassroomsTeachingInput
 }
 
-input ClassroomUpdateWithWhereUniqueWithoutUsersInput {
-  where: ClassroomWhereUniqueInput!
-  data: ClassroomUpdateWithoutUsersDataInput!
+input ClassroomUpdateWithoutTeachersDataInput {
+  name: String
+  description: String
+  status: Int
+  flags: Int
+  notes: String
+  studentCourses: CourseUpdateManyWithoutClassroomsInput
 }
 
-input ClassroomUpsertWithWhereUniqueWithoutUsersInput {
+input ClassroomUpdateWithWhereUniqueWithoutStudentCoursesInput {
   where: ClassroomWhereUniqueInput!
-  update: ClassroomUpdateWithoutUsersDataInput!
-  create: ClassroomCreateWithoutUsersInput!
+  data: ClassroomUpdateWithoutStudentCoursesDataInput!
+}
+
+input ClassroomUpdateWithWhereUniqueWithoutTeachersInput {
+  where: ClassroomWhereUniqueInput!
+  data: ClassroomUpdateWithoutTeachersDataInput!
+}
+
+input ClassroomUpsertWithWhereUniqueWithoutStudentCoursesInput {
+  where: ClassroomWhereUniqueInput!
+  update: ClassroomUpdateWithoutStudentCoursesDataInput!
+  create: ClassroomCreateWithoutStudentCoursesInput!
+}
+
+input ClassroomUpsertWithWhereUniqueWithoutTeachersInput {
+  where: ClassroomWhereUniqueInput!
+  update: ClassroomUpdateWithoutTeachersDataInput!
+  create: ClassroomCreateWithoutTeachersInput!
 }
 
 input ClassroomWhereInput {
@@ -410,9 +458,12 @@ input ClassroomWhereInput {
 
   """All values not ending with the given string."""
   notes_not_ends_with: String
-  users_every: UserWhereInput
-  users_some: UserWhereInput
-  users_none: UserWhereInput
+  studentCourses_every: CourseWhereInput
+  studentCourses_some: CourseWhereInput
+  studentCourses_none: CourseWhereInput
+  teachers_every: UserWhereInput
+  teachers_some: UserWhereInput
+  teachers_none: UserWhereInput
 }
 
 input ClassroomWhereUniqueInput {
@@ -424,6 +475,7 @@ type Course implements Node {
   status: Int!
   flags: Int!
   parent(where: EnrollmentWhereInput): Enrollment!
+  classrooms(where: ClassroomWhereInput, orderBy: ClassroomOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Classroom!]
   masteries(where: MasteryWhereInput, orderBy: MasteryOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Mastery!]
   surveys(where: SurveyWhereInput, orderBy: SurveyOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Survey!]
 }
@@ -442,8 +494,14 @@ input CourseCreateInput {
   status: Int!
   flags: Int!
   parent: EnrollmentCreateOneWithoutCoursesInput!
+  classrooms: ClassroomCreateManyWithoutStudentCoursesInput
   masteries: MasteryCreateManyWithoutParentInput
   surveys: SurveyCreateManyWithoutParentInput
+}
+
+input CourseCreateManyWithoutClassroomsInput {
+  create: [CourseCreateWithoutClassroomsInput!]
+  connect: [CourseWhereUniqueInput!]
 }
 
 input CourseCreateManyWithoutParentInput {
@@ -461,16 +519,26 @@ input CourseCreateOneWithoutSurveysInput {
   connect: CourseWhereUniqueInput
 }
 
+input CourseCreateWithoutClassroomsInput {
+  status: Int!
+  flags: Int!
+  parent: EnrollmentCreateOneWithoutCoursesInput!
+  masteries: MasteryCreateManyWithoutParentInput
+  surveys: SurveyCreateManyWithoutParentInput
+}
+
 input CourseCreateWithoutMasteriesInput {
   status: Int!
   flags: Int!
   parent: EnrollmentCreateOneWithoutCoursesInput!
+  classrooms: ClassroomCreateManyWithoutStudentCoursesInput
   surveys: SurveyCreateManyWithoutParentInput
 }
 
 input CourseCreateWithoutParentInput {
   status: Int!
   flags: Int!
+  classrooms: ClassroomCreateManyWithoutStudentCoursesInput
   masteries: MasteryCreateManyWithoutParentInput
   surveys: SurveyCreateManyWithoutParentInput
 }
@@ -479,6 +547,7 @@ input CourseCreateWithoutSurveysInput {
   status: Int!
   flags: Int!
   parent: EnrollmentCreateOneWithoutCoursesInput!
+  classrooms: ClassroomCreateManyWithoutStudentCoursesInput
   masteries: MasteryCreateManyWithoutParentInput
 }
 
@@ -553,8 +622,18 @@ input CourseUpdateInput {
   status: Int
   flags: Int
   parent: EnrollmentUpdateOneWithoutCoursesInput
+  classrooms: ClassroomUpdateManyWithoutStudentCoursesInput
   masteries: MasteryUpdateManyWithoutParentInput
   surveys: SurveyUpdateManyWithoutParentInput
+}
+
+input CourseUpdateManyWithoutClassroomsInput {
+  create: [CourseCreateWithoutClassroomsInput!]
+  connect: [CourseWhereUniqueInput!]
+  disconnect: [CourseWhereUniqueInput!]
+  delete: [CourseWhereUniqueInput!]
+  update: [CourseUpdateWithWhereUniqueWithoutClassroomsInput!]
+  upsert: [CourseUpsertWithWhereUniqueWithoutClassroomsInput!]
 }
 
 input CourseUpdateManyWithoutParentInput {
@@ -582,16 +661,26 @@ input CourseUpdateOneWithoutSurveysInput {
   upsert: CourseUpsertWithoutSurveysInput
 }
 
+input CourseUpdateWithoutClassroomsDataInput {
+  status: Int
+  flags: Int
+  parent: EnrollmentUpdateOneWithoutCoursesInput
+  masteries: MasteryUpdateManyWithoutParentInput
+  surveys: SurveyUpdateManyWithoutParentInput
+}
+
 input CourseUpdateWithoutMasteriesDataInput {
   status: Int
   flags: Int
   parent: EnrollmentUpdateOneWithoutCoursesInput
+  classrooms: ClassroomUpdateManyWithoutStudentCoursesInput
   surveys: SurveyUpdateManyWithoutParentInput
 }
 
 input CourseUpdateWithoutParentDataInput {
   status: Int
   flags: Int
+  classrooms: ClassroomUpdateManyWithoutStudentCoursesInput
   masteries: MasteryUpdateManyWithoutParentInput
   surveys: SurveyUpdateManyWithoutParentInput
 }
@@ -600,7 +689,13 @@ input CourseUpdateWithoutSurveysDataInput {
   status: Int
   flags: Int
   parent: EnrollmentUpdateOneWithoutCoursesInput
+  classrooms: ClassroomUpdateManyWithoutStudentCoursesInput
   masteries: MasteryUpdateManyWithoutParentInput
+}
+
+input CourseUpdateWithWhereUniqueWithoutClassroomsInput {
+  where: CourseWhereUniqueInput!
+  data: CourseUpdateWithoutClassroomsDataInput!
 }
 
 input CourseUpdateWithWhereUniqueWithoutParentInput {
@@ -616,6 +711,12 @@ input CourseUpsertWithoutMasteriesInput {
 input CourseUpsertWithoutSurveysInput {
   update: CourseUpdateWithoutSurveysDataInput!
   create: CourseCreateWithoutSurveysInput!
+}
+
+input CourseUpsertWithWhereUniqueWithoutClassroomsInput {
+  where: CourseWhereUniqueInput!
+  update: CourseUpdateWithoutClassroomsDataInput!
+  create: CourseCreateWithoutClassroomsInput!
 }
 
 input CourseUpsertWithWhereUniqueWithoutParentInput {
@@ -718,6 +819,9 @@ input CourseWhereInput {
   """All values greater than or equal the given value."""
   flags_gte: Int
   parent: EnrollmentWhereInput
+  classrooms_every: ClassroomWhereInput
+  classrooms_some: ClassroomWhereInput
+  classrooms_none: ClassroomWhereInput
   masteries_every: MasteryWhereInput
   masteries_some: MasteryWhereInput
   masteries_none: MasteryWhereInput
@@ -2822,8 +2926,8 @@ type User implements Node {
   type: Int!
   status: Int!
   flags: Int!
-  classrooms(where: ClassroomWhereInput, orderBy: ClassroomOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Classroom!]
   enrollment(where: EnrollmentWhereInput): Enrollment
+  classroomsTeaching(where: ClassroomWhereInput, orderBy: ClassroomOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Classroom!]
 }
 
 """A connection to a list of items."""
@@ -2845,12 +2949,12 @@ input UserCreateInput {
   type: Int!
   status: Int!
   flags: Int!
-  classrooms: ClassroomCreateManyWithoutUsersInput
   enrollment: EnrollmentCreateOneWithoutStudentInput
+  classroomsTeaching: ClassroomCreateManyWithoutTeachersInput
 }
 
-input UserCreateManyWithoutClassroomsInput {
-  create: [UserCreateWithoutClassroomsInput!]
+input UserCreateManyWithoutClassroomsTeachingInput {
+  create: [UserCreateWithoutClassroomsTeachingInput!]
   connect: [UserWhereUniqueInput!]
 }
 
@@ -2859,7 +2963,7 @@ input UserCreateOneWithoutEnrollmentInput {
   connect: UserWhereUniqueInput
 }
 
-input UserCreateWithoutClassroomsInput {
+input UserCreateWithoutClassroomsTeachingInput {
   email: String!
   password: String!
   honorific: String
@@ -2880,7 +2984,7 @@ input UserCreateWithoutEnrollmentInput {
   type: Int!
   status: Int!
   flags: Int!
-  classrooms: ClassroomCreateManyWithoutUsersInput
+  classroomsTeaching: ClassroomCreateManyWithoutTeachersInput
 }
 
 """An edge in a connection."""
@@ -2977,17 +3081,17 @@ input UserUpdateInput {
   type: Int
   status: Int
   flags: Int
-  classrooms: ClassroomUpdateManyWithoutUsersInput
   enrollment: EnrollmentUpdateOneWithoutStudentInput
+  classroomsTeaching: ClassroomUpdateManyWithoutTeachersInput
 }
 
-input UserUpdateManyWithoutClassroomsInput {
-  create: [UserCreateWithoutClassroomsInput!]
+input UserUpdateManyWithoutClassroomsTeachingInput {
+  create: [UserCreateWithoutClassroomsTeachingInput!]
   connect: [UserWhereUniqueInput!]
   disconnect: [UserWhereUniqueInput!]
   delete: [UserWhereUniqueInput!]
-  update: [UserUpdateWithWhereUniqueWithoutClassroomsInput!]
-  upsert: [UserUpsertWithWhereUniqueWithoutClassroomsInput!]
+  update: [UserUpdateWithWhereUniqueWithoutClassroomsTeachingInput!]
+  upsert: [UserUpsertWithWhereUniqueWithoutClassroomsTeachingInput!]
 }
 
 input UserUpdateOneWithoutEnrollmentInput {
@@ -2998,7 +3102,7 @@ input UserUpdateOneWithoutEnrollmentInput {
   upsert: UserUpsertWithoutEnrollmentInput
 }
 
-input UserUpdateWithoutClassroomsDataInput {
+input UserUpdateWithoutClassroomsTeachingDataInput {
   email: String
   password: String
   honorific: String
@@ -3019,12 +3123,12 @@ input UserUpdateWithoutEnrollmentDataInput {
   type: Int
   status: Int
   flags: Int
-  classrooms: ClassroomUpdateManyWithoutUsersInput
+  classroomsTeaching: ClassroomUpdateManyWithoutTeachersInput
 }
 
-input UserUpdateWithWhereUniqueWithoutClassroomsInput {
+input UserUpdateWithWhereUniqueWithoutClassroomsTeachingInput {
   where: UserWhereUniqueInput!
-  data: UserUpdateWithoutClassroomsDataInput!
+  data: UserUpdateWithoutClassroomsTeachingDataInput!
 }
 
 input UserUpsertWithoutEnrollmentInput {
@@ -3032,10 +3136,10 @@ input UserUpsertWithoutEnrollmentInput {
   create: UserCreateWithoutEnrollmentInput!
 }
 
-input UserUpsertWithWhereUniqueWithoutClassroomsInput {
+input UserUpsertWithWhereUniqueWithoutClassroomsTeachingInput {
   where: UserWhereUniqueInput!
-  update: UserUpdateWithoutClassroomsDataInput!
-  create: UserCreateWithoutClassroomsInput!
+  update: UserUpdateWithoutClassroomsTeachingDataInput!
+  create: UserCreateWithoutClassroomsTeachingInput!
 }
 
 input UserWhereInput {
@@ -3353,10 +3457,10 @@ input UserWhereInput {
 
   """All values greater than or equal the given value."""
   flags_gte: Int
-  classrooms_every: ClassroomWhereInput
-  classrooms_some: ClassroomWhereInput
-  classrooms_none: ClassroomWhereInput
   enrollment: EnrollmentWhereInput
+  classroomsTeaching_every: ClassroomWhereInput
+  classroomsTeaching_some: ClassroomWhereInput
+  classroomsTeaching_none: ClassroomWhereInput
 }
 
 input UserWhereUniqueInput {

--- a/server/src/resolvers/Query/classroom.js
+++ b/server/src/resolvers/Query/classroom.js
@@ -1,0 +1,11 @@
+/*
+  TODO Query/classroom.js notes
+  Make it so that querying classrooms only gets students whose course is currently active.
+  Basically, if a student switches courses, they will no longer exist.
+  Additionally, perhaps create an alternative query where it DOES show these inactive course
+  students so that if there is a case where a teacher is wondering why one of their students
+  suddenly went missing (in the future where courses are assignable. For now I'm just concerned
+  about a single enrollment and a single course, this is all future-proofing) there should be a way
+  to discover them! Either that addition will be "here's everyone, even the inactive students"
+  or "here's just the inactive students".
+*/

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -50,7 +50,8 @@ type AuthPayload {
   user: User!
 }
 
-# For public use. It does not expose password, email, enrollment, or classrooms.
+# For public-ish use. It does not expose password, email, enrollment, or classroomsTeaching.
+# It does, however, expose first and last names. So take note about ever making this truly public.
 type User {
   id: ID!
   honorific: String
@@ -71,8 +72,8 @@ type PrivateUser {
   type: Int!
   status: Int!
   flags: Int!
-  classrooms: [Classroom!]!
   enrollment: Enrollment
+  classroomsTeaching: [Classroom!]!
 }
 
 ### QA Object data schema and its numerous children below

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -50,6 +50,32 @@ async function getUserData(ctx, userId, fields) {
 
 
 /**
+ * Get user details by an array of UserIds. This function can expose sensitive user information
+ * so call it only in authorized situations.
+ * IT DOES NOT CHECK AUTHORIZATION.
+ * @param ctx
+ * @param userIds
+ * @param fields
+ * @returns {Promise<void>}
+ */
+async function getUsersData(ctx, userIds, fields) {
+  const whereClause = {
+    where: {
+      OR: [],
+    },
+  };
+  whereClause.where.OR = userIds.map(userId => ({ id: userId }));
+
+  const users = await ctx.db.query.users(whereClause, fields);
+  if (users) {
+    return users;
+  }
+
+  throw new UserNotFound();
+}
+
+
+/**
  * Grab fields from a user by their id. If the calling user is the target (they're performing an
  * action on their own account, typically) save a wasteful query.
  * IT DOES NOT CHECK AUTHORIZATION.
@@ -221,6 +247,7 @@ async function checkAuth(
 module.exports = {
   getUserId,
   getUserData,
+  getUsersData,
   targetStudentDataHelper,
   getStudentActiveCourseId,
   checkAuth,


### PR DESCRIPTION
…ndled.

Essentially, students no longer are connected by their User row to a Classroom, they are now connected via their Course. Teachers are now treated slightly separately and are connected to the Classroom directly by their User row via "classroomsTeaching" field.

Students and their Courses are far more decisive. They will no longer be considered a member of a classroom if their connected course is not active. And actually, this might be a good time to change the name "Course" perhaps to "Program"?

Massive re-write of mutation/classroom.js to support the slightly confusing path that student users need to be taken on [User>Enrollment>Course(s)] to be properly manipulated. I also reduced repeated code between addUsersToClassroom() and removeUsersFromClassroom() by moving and sharing logic between them in the private (not exported) function changeClassroomMembers().

Improvement to assignStudentNewCourse() where it'll automatically deactivate any existing active courses when a new one is created.

Added utils.getUsersData() - just like getUserData but for multiple user IDs.

For the sake of a big TODO tag created new file Query/classroom.js with notes I realized for ISSUE-013.

I really should look into how to unit test GraphQL queries and mutations. That'd be really useful about now...