### PR TITLE
ISSUE-070 Server: Wrote updateUserProfile and updateUserStates mutati…

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,14 +1,17 @@
 # 📐🗄🗂🗳📏 metric-teacher Server 📏🗳🗂🗄📐
 This is the documentation for the server side of the metric-teacher project, a Node.js GraphQL API software project.
 
+This is a project conceived and implemented completely by myself, Kyle Geib. UW Bothell educated, Seattle located SDET turned Product Support Engineer turning to eventual JavaScript Full-Stack Developer. I've been a professional programmer since 2013-01-02.
+
 It is written with...
 * Prisma - [github.com/prismagraphql/prisma](https://github.com/prismagraphql/prisma)
-* Prisma's GraphQL-Yoga️ - [github.com/prismagraphql/graphql-yoga](https://github.com/prismagraphql/graphql-yoga)
-* Prisma's Prisma-Binding - [github.com/prismagraphql/prisma-binding](https://github.com/prismagraphql/prisma-binding)
+    * GraphQL-Yoga️ - [github.com/prismagraphql/graphql-yoga](https://github.com/prismagraphql/graphql-yoga)
+    * Prisma-Binding - [github.com/prismagraphql/prisma-binding](https://github.com/prismagraphql/prisma-binding)
 * dcodeIO's bcrypt.js - [github.com/dcodeIO/bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
 * auth0's node-jsonwebtoken - [github.com/auth0/node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken)
 * Facebook's Jest - [jestjs.io](http://jestjs.io/)
 * Javier Cejudo's linear-converter - [github.com/javiercejudo/linear-converter](https://github.com/javiercejudo/linear-converter)
+    * linear-presets - [github.com/javiercejudo/linear-presets](https://github.com/javiercejudo/linear-presets)
 * Lodash - [lodash.com](https://lodash.com/)
 
 It uses [**MySQL**](https://www.mysql.com/) for its Database, [**Prisma**](https://www.prisma.io/) for its GraphQL Database, and [**Docker**](https://www.docker.com/) + [**Docker-Compose**](https://docs.docker.com/compose/overview/) to build and run the virtual machines for these programs.
@@ -19,7 +22,7 @@ I wrote it using the following tools:
 * JetBrain's WebStorm IDE - [jetbrains.com/webstorm](https://www.jetbrains.com/webstorm/)
 * Prisma's GraphQL Playground IDE - [github.com/prismagraphql/graphql-playground](https://github.com/prismagraphql/graphql-playground)
 * Sublime HQ's Sublime Text 3 Text Editor - [sublimetext.com/3](https://www.sublimetext.com/3)
-* syntevo's Smart Git Git Client - [syntevo.com/smartgit](https://www.syntevo.com/smartgit/)
+* syntevo's SmartGit Git Client - [syntevo.com/smartgit](https://www.syntevo.com/smartgit/)
 
 *First commit made on 2018-05-07 but an idea in my head since mid-2015.*
 

--- a/server/src/constants.js
+++ b/server/src/constants.js
@@ -1,4 +1,7 @@
 const constants = {
+  // Server Configurations
+  BCRYPT_SALT_LENGTH: 10,
+
   // Database Constants
   // Generic
   FLAGS_NONE: 0,

--- a/server/src/resolvers/Mutation/auth.js
+++ b/server/src/resolvers/Mutation/auth.js
@@ -1,14 +1,22 @@
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 
+const {
+  BCRYPT_SALT_LENGTH,
+  USER_TYPE_STUDENT,
+  USER_STATUS_NORMAL,
+  FLAGS_NONE,
+} = require("../../constants");
+
 const auth = {
-  async signup(parent, args, ctx, info) {
+  async signup(parent, args, ctx) {
+    // All new users are given these settings. Can't allow people to sign-up as Admins, after all!
     const defaultArgs = {
-      type: 0,
-      status: 0,
-      flags: 0,
+      type: USER_TYPE_STUDENT,
+      status: USER_STATUS_NORMAL,
+      flags: FLAGS_NONE,
     };
-    const password = await bcrypt.hash(args.password, 10);
+    const password = await bcrypt.hash(args.password, BCRYPT_SALT_LENGTH);
     const user = await ctx.db.mutation.createUser({
       data: { ...defaultArgs, ...args, password },
     });

--- a/server/src/resolvers/Mutation/user.js
+++ b/server/src/resolvers/Mutation/user.js
@@ -1,6 +1,182 @@
-const user = {
+const bcrypt = require("bcryptjs");
 
+const {
+  checkAuth,
+} = require("../../utils");
+
+const {
+  AuthError,
+  UserNotFound,
+} = require("../../errors");
+
+const {
+  BCRYPT_SALT_LENGTH,
+  USER_STATUS_NORMAL,
+  USER_TYPE_STUDENT,
+  USER_TYPE_TEACHER,
+  USER_TYPE_MODERATOR,
+  USER_TYPE_ADMIN,
+} = require("../../constants");
+
+const user = {
+  /**
+   * Mutation providing a method to self-update user profile information. There are some additional
+   * checks on Moderators disallowing them from updating other Moderators or Admins. Admins, on the
+   * other hand, have full power.
+   * TODO - Email validity check (it's not just for the client these days!!)
+   * TODO - Email confirmations (waaaay in the future no doubt!)
+   * TODO - Password check (minimum length, complexity requirements, easy password blocking)
+   * TODO - Name check (no numerals, no odd punctuation, etc)
+   * TODO - Honorific check (maybe?)
+   * @param parent
+   * @param args
+   *        userid: ID!
+   *        email: String
+   *        password: String
+   *        honorific: String
+   *        fname: String
+   *        lname: String
+   * @param ctx
+   * @param info
+   * @returns PrivateUser!
+   */
+  async updateUserProfile(parent, args, ctx, info) {
+    const callingUserData = await checkAuth(ctx, {
+      type: USER_TYPE_STUDENT,
+      status: USER_STATUS_NORMAL,
+      action: "updateUserProfile",
+    });
+
+    const targetUserData = await ctx.db.query.user({ where: { id: args.userid } }, `
+      {
+        id
+        type
+      }
+    `);
+
+    // Check the User exists.
+    if (targetUserData === null) {
+      throw new UserNotFound(args.courseid);
+    }
+
+    // A Student or Teacher can update their own info and moderators or better can as well.
+    if (callingUserData.id !== targetUserData.id &&
+      callingUserData.type < USER_TYPE_MODERATOR) {
+      throw new AuthError(null, "updateUserProfile");
+    }
+
+    // Do some Moderator checking...
+    moderatorPermissionsCheck(targetUserData, callingUserData, args, "updateUserProfile");
+
+    // Construct the update payload carefully...
+    const dataPayload = {};
+
+    // Email and passwords cannot be made blank.
+    if (args.email) dataPayload.email = args.email;
+    if (args.password) dataPayload.password = await bcrypt.hash(args.password, BCRYPT_SALT_LENGTH);
+
+    // First and last names can be made blank.
+    if (args.fname !== undefined) dataPayload.fname = args.fname;
+    if (args.lname !== undefined) dataPayload.lname = args.lname;
+
+    // Only allow honorifics for teachers.
+    if (args.honorific !== undefined && targetUserData.type === USER_TYPE_TEACHER) {
+      dataPayload.honorific = args.honorific;
+    }
+
+    // Fire off the mutation!
+    return ctx.db.mutation.updateUser({
+      where: { id: args.userid },
+      data: dataPayload,
+    }, info);
+  },
+
+
+  /**
+   * Mutation providing administrative-style updates to a User row. This includes changing the
+   * type, status, and flags of a User. There are some additional checks on Moderators disallowing
+   * them from updating other Moderators or Admins. Admins, on the other hand, have full power.
+   * @param parent
+   * @param args
+   *        userid: ID!
+   *        type: Int
+   *        status: Int
+   *        flags: Int
+   * @param ctx
+   * @param info
+   * @returns PrivateUser!
+   */
+  async updateUserStates(parent, args, ctx, info) {
+    const callingUserData = await checkAuth(ctx, {
+      type: USER_TYPE_MODERATOR,
+      status: USER_STATUS_NORMAL,
+      action: "updateUserStates",
+    });
+
+    const targetUserData = await ctx.db.query.user({ where: { id: args.userid } }, `
+      {
+        id
+        type
+      }
+    `);
+
+    // Check the User exists.
+    if (targetUserData === null) {
+      throw new UserNotFound(args.courseid);
+    }
+
+    // A Student or Teacher can update their own info and moderators or better can as well.
+    // I KNOW THIS IS POINTLESS (because of checkAuth above) but it helps me sleep at night!
+    if (callingUserData.id !== targetUserData.id &&
+      callingUserData.type < USER_TYPE_MODERATOR) {
+      throw new AuthError(null, "updateUserStates");
+    }
+
+    // Do some Moderator checking...
+    moderatorPermissionsCheck(targetUserData, callingUserData, args, "updateUserStates");
+
+    // Construct the update payload carefully...
+    const dataPayload = {};
+    if (args.type) dataPayload.type = args.type;
+    if (args.status) dataPayload.status = args.status;
+    if (args.flags) dataPayload.flags = args.flags;
+
+    // Only Teachers can have honorifics, remove it if they were once a teacher. ...This will never
+    // happen...
+    if (targetUserData.type === USER_TYPE_TEACHER && args.type !== USER_TYPE_TEACHER) {
+      dataPayload.honorific = null;
+    }
+
+    // Fire off the mutation!
+    return ctx.db.mutation.updateUser({
+      where: { id: args.userid },
+      data: dataPayload,
+    }, info);
+  },
 };
 
+
+/**
+ * Helper function places limits on the powers of Moderators.
+ * @param targetUserData
+ * @param callingUserData
+ * @param args
+ * @param actionName
+ */
+function moderatorPermissionsCheck(targetUserData, callingUserData, args, actionName) {
+  // A moderator cannot affect other moderators or admins. But they can change themselves.
+  if (callingUserData.id !== targetUserData.id &&
+    targetUserData.type >= USER_TYPE_MODERATOR &&
+    callingUserData.type < USER_TYPE_ADMIN) {
+    throw new AuthError("Only Admins can change other Moderators or better", actionName);
+  }
+
+  if (args.type) {
+    // Only Admins can change a User's type to Moderator or better.
+    if (args.type >= USER_TYPE_MODERATOR && callingUserData.type < USER_TYPE_ADMIN) {
+      throw new AuthError("Only Admins can make Moderators or better", actionName);
+    }
+  }
+}
 
 module.exports = { user };

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -62,6 +62,8 @@ type Mutation {
   # User Mutations
   signup(email: String!, password: String!, fname: String!, lname: String!): AuthPayload!
   login(email: String!, password: String!): AuthPayload!
+  updateUserProfile(userid: ID!, email: String, password: String, honorific: String, fname: String, lname: String): PrivateUser!
+  updateUserStates(userid: ID!, type: Int, status: Int, flags: Int): PrivateUser!
 
   # Student Mutations
   ## Enrollment


### PR DESCRIPTION
…ons.

I split the duties into two different mutations as their use and nature are very different. updateUserStates is intended only for Moderators and Admins while updateUserProfile is for any user.

Wrote the first rules limiting the power of Moderators, finally giving permissions that belong only to Admins users.

Introducing constants to auth.js including the introduction of the first server configuration constant, BCRYPT_SALT_LENGTH.

Little presentational updates to the README.