### PR TITLE
ISSUE-103 Server: Students and Teachers now must supply old password …

### DIFF
--- a/server/src/errors.js
+++ b/server/src/errors.js
@@ -30,6 +30,12 @@ class UserMustBe extends Error {
   }
 }
 
+class ExistingPasswordRequired extends Error {
+  constructor(action) {
+    super(`Existing password must be supplied to ${action}`);
+  }
+}
+
 class CourseNotFound extends Error {
   constructor(courseId) {
     super(`Course ${courseId} not found`);
@@ -239,6 +245,7 @@ module.exports = {
   GraphQlDumpWarning,
   UserNotFound,
   UserMustBe,
+  ExistingPasswordRequired,
   CourseNotFound,
   CourseInactive,
   CourseNoSubSubjectsAdded,

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -67,7 +67,7 @@ type Mutation {
   login(email: String!, password: String!): AuthPayload!
 
   # User Mutations
-  updateUserProfile(userid: ID!, email: String, password: String, honorific: String, fname: String, lname: String): PrivateUser!
+  updateUserProfile(userid: ID!, email: String, password: PasswordInput, honorific: String, fname: String, lname: String): PrivateUser!
   updateUserStates(userid: ID!, type: Int, status: Int, flags: Int): PrivateUser!
 
   # Student Mutations
@@ -106,6 +106,11 @@ type Mutation {
 }
 
 ### Inputs
+input PasswordInput {
+  new: String
+  old: String
+}
+
 input MasteryScoreInput {
   subsubjectid: ID!
   score: Int!


### PR DESCRIPTION
…to set new password and new emails.

Students, teachers, AND moderators must supply their old password to change their password or email. Moderators can change the password or email of students and teachers without the old password. Admins can change everyone's password or email without old passwords, even other admins.

Normal limitations on Moderators (they cannot change other moderators or admins) still apply as before.

Some really freaking hairy boolean logic in the if statements but I'm pretty confident they're right!

Fixed a stupid little mistake in the throw new UserNotFound() error.

New ExistingPasswordRequired error.

New PasswordInput input for the schema. Pretty neat.