### PR TITLE
ISSUE-177 Client: Added support for typing in negative numbers by all…

### DIFF
--- a/client/src/components/misc/LoadingButton.js
+++ b/client/src/components/misc/LoadingButton.js
@@ -66,7 +66,8 @@ class LoadingButton extends PureComponent {
               {...this.props.buttonProps}
               onClick={this.openModal}
             >
-              {this.props.error ? "Error!" : this.props.buttonText}
+              {(this.props.error && this.props.buttonDisableOnError) ?
+                "Error!" : this.props.buttonText}
             </Button>
           }
           open={this.state.modalOpen}

--- a/client/src/components/question/details/QuestionDetailsAnswer.js
+++ b/client/src/components/question/details/QuestionDetailsAnswer.js
@@ -238,12 +238,7 @@ const QuestionDetailsAnswer = class QuestionDetailsAnswer extends PureComponent 
                               dropdownProps={{ pointing: "bottom" }}
                             />
                             :
-                            <Input
-                              value={choice.unit || ""}
-                              placeholder="Unit"
-                              transparent
-                              onChange={(e, { value }) => this.handleChoiceUnitChange(index, value)}
-                            />
+                            <p>Select a SubSubject first!</p>
                           }
                           {index === 0 &&
                             <Popup
@@ -309,13 +304,19 @@ const QuestionDetailsAnswer = class QuestionDetailsAnswer extends PureComponent 
               :
               <span>
                 {this.props.editMode ?
-                  <Button
-                    compact
-                    color="olive"
-                    onClick={this.handleFirstChoices}
-                  >
-                    Make first choices
-                  </Button>
+                  <div>
+                    {(this.props.subjectName && this.props.subSubjectToMetric !== null) ?
+                      <Button
+                        compact
+                        color="olive"
+                        onClick={this.handleFirstChoices}
+                      >
+                        Make first choices
+                      </Button>
+                      :
+                      <p>Select a SubSubject first!</p>
+                    }
+                  </div>
                   :
                   <p>No choices!</p>
                 }
@@ -425,13 +426,7 @@ const QuestionDetailsAnswer = class QuestionDetailsAnswer extends PureComponent 
                           dropdownProps={{ pointing: "bottom" }}
                         />
                         :
-                        <Input
-                          onChange={this.handleUnitChange}
-                          value={this.props.unit || ""}
-                          placeholder="..."
-                          transparent
-                          fluid
-                        />
+                        <p>Select a SubSubject first!</p>
                       }
                     </List.Description>
                     :

--- a/client/src/components/question/details/QuestionDetailsQuestion.js
+++ b/client/src/components/question/details/QuestionDetailsQuestion.js
@@ -244,13 +244,7 @@ class QuestionDetailsQuestion extends PureComponent {
                           dropdownProps={{ pointing: "bottom" }}
                         />
                         :
-                        <Input
-                          onChange={this.handleRangeUnitChange}
-                          value={this.props.range && this.props.range.unit}
-                          placeholder="..."
-                          transparent
-                          fluid
-                        />
+                        <p>Select a SubSubject first!</p>
                       }
                     </List.Description>
                     :

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -872,6 +872,8 @@ const flagDescriber = (flagsDictionary, flags) => {
  * or not. Unlike just straight isDecimal it won't reject typing a decimal at the end.
  * That is the worst case scenario: a user can type "5." and possibly submit it, but it's not too
  * bad since parseInt() and parseFloat() both read it as 5
+ * It also accepts a single "-" to prevent a user from being denied the ability to type in a
+ * negative number. Catching input of "-" will need to be handled elsewhere, so BE CAREFUL!
  * @param input
  * @returns {*}
  */
@@ -883,6 +885,8 @@ const isDecimalTyped = (input) => {
   }
   if (stringInput[stringInput.length - 1] === ".") {
     return isDecimal(stringInput.slice(0, stringInput.length - 1));
+  } else if (stringInput === "-") {
+    return true;
   } else {
     return isDecimal(stringInput);
   }

--- a/server/src/constants.js
+++ b/server/src/constants.js
@@ -482,6 +482,12 @@ const constants = {
     velocity: "metresSecond",
   },
 
+  // Define the list of units that negative values are allowed.
+  NEGATIVE_UNITS: [
+    "f",
+    "c",
+  ],
+
 };
 
 module.exports = constants;

--- a/server/src/logic/utils.js
+++ b/server/src/logic/utils.js
@@ -29,6 +29,7 @@ const {
   QUESTION_DIFFICULTY_RANGES,
   WRITTEN_ANSWER_UNIT,
   UNITS,
+  NEGATIVE_UNITS,
 } = require("../constants");
 
 /**
@@ -275,12 +276,17 @@ function answerSyntaxFormatter(text = null, choicesInput = null, conversionInput
         const parsedValue = parseFloat(choice.value);
         if (Math.abs(parsedValue) >= NUMBER_INPUT_MAXIMUM) {
           choicesInputErrors.push(  // Yes, says "exceed" when it's actually >=. It reads better.
-            `Unit choice '${choice.value}' exceeds maximum value (+/- ${NUMBER_INPUT_MAXIMUM})`,
+            `Choice value '${choice.value}' exceeds maximum value (+/- ${NUMBER_INPUT_MAXIMUM})`,
           );
         }
         if (parsedValue !== 0 && Math.abs(parsedValue) <= NUMBER_INPUT_MINIMUM) {
           choicesInputErrors.push(
-            `Unit choice '${choice.value}' is smaller than minimum fraction (+/- ${NUMBER_INPUT_MINIMUM})`,
+            `Choice value '${choice.value}' is smaller than minimum fraction (+/- ${NUMBER_INPUT_MINIMUM})`,
+          );
+        }
+        if (parsedValue < 0 && !NEGATIVE_UNITS.includes(choice.unit)) {
+          choicesInputErrors.push(
+            `Choice value '${choice.value}' cannot be negative for unit '${choice.unit}'`,
           );
         }
       }


### PR DESCRIPTION
…owing the first character to be "-".

If the user submits it then it'll fail the server-side entry by being an unacceptable value (non-float).

Fixed little bug in LoadingButton where the button text would flip to say "ERROR!" if it had an error in modal mode even when the prop buttonDisableOnError was set to false.

I did not add negative checking to survey entries as I will instead rely on the survey range instead.

Got rid of the backup Input components for Units in QuestionDetailsAnswer and QuestionDetailsQuestion and replaced them with messages saying to select a SubSubject first. It was confusing UI to say the least so I decided to remove it. I also removed the button for "Make First Choices" until the SubSubject was selected.

Server: Added rejection of negative values for incompatible units. Also updated some error messaging.

Defined a list of negative value compatible units (Fahrenheit and Celsius, as I plan to support temperature differences later on I decided to define a clean array of units instead of relying on a simple if statement).