### PR TITLE
ISSUE-197 Server: Fixed issue with broken questionUpdate mutation.

### DIFF
--- a/server/src/resolvers/Mutation/question.js
+++ b/server/src/resolvers/Mutation/question.js
@@ -230,8 +230,7 @@ const question = {
         upper: targetQa.question.data.conversion.range.top.value,
         unit: targetQa.question.data.conversion.range.top.unit,
         step: targetQa.question.data.conversion.step,
-      } : undefined,
-      surveyrangeinput: (targetQa.question.data && targetQa.question.data.survey) ? {
+      } : (targetQa.question.data && targetQa.question.data.survey) ? {
         lower: targetQa.question.data.survey.range.bottom.value,
         upper: targetQa.question.data.survey.range.top.value,
         unit: targetQa.question.data.survey.range.top.unit,
@@ -249,7 +248,7 @@ const question = {
         })),
         choicesoffered: targetQa.answer.data.multiple.choicesOffered,
       } : undefined,
-      rangeinput: (
+      conversioninput: (
         targetQa.answer.type === QUESTION_TYPE_CONVERSION ||
         targetQa.answer.type === QUESTION_TYPE_SURVEY) ? {
           unit: targetQa.answer.data.unit,
@@ -268,15 +267,11 @@ const question = {
     switch (newType) {
     case QUESTION_TYPE_WRITTEN:
       if (newQuestionInput.rangeinput) newQuestionInput.rangeinput = undefined;
-      if (newQuestionInput.surveyrangeinput) newQuestionInput.surveyrangeinput = undefined;
-      if (newAnswerInput.rangeinput) newAnswerInput.rangeinput = undefined;
+      if (newAnswerInput.conversioninput) newAnswerInput.conversioninput = undefined;
       break;
+    // eslint-disable-next-line no-fallthrough
     case QUESTION_TYPE_CONVERSION:
-      if (newQuestionInput.surveyrangeinput) newQuestionInput.surveyrangeinput = undefined;
-      if (newAnswerInput.multiplechoiceinput) newAnswerInput.multiplechoiceinput = undefined;
-      break;
     case QUESTION_TYPE_SURVEY:
-      if (newQuestionInput.rangeinput) newQuestionInput.rangeinput = undefined;
       if (newAnswerInput.multiplechoiceinput) newAnswerInput.multiplechoiceinput = undefined;
       break;
     default:


### PR DESCRIPTION
Turns out in ISSUE-138 and commit 6e2bd8aa I had reduced some redundancy in the question-side of the Question submission schema (QuestionQuestionInput) by collapsing two range objects "conversioninput: ConversionQuestionInput" and "surveyrangeinput: RangeQuestionInput" (completely guilty of inconsistent naming for both the field names and the input names especially considering the two input objects were identical in structure!) to a new field "rangeinput" responsible for "[64,82f(1)s]".

Well, by chance there was another field named "conversioninput" in the sibling input (QuestionAnswerInput). In the code I went in and mistakingly renamed that field also to "rangeinput", which was totally wrong, as down the line in the functions checkAndParseQuestionAnswerInputs() and answerSyntaxFormatter() it was counting on there to be a property named "conversioninput" which was responsible for "[c(1)a]". It was now named "rangeinput". Bad!

So, I returned the name for the answerInput.rangeinput back to answerInput.conversioninput.

Additionally, I had renamed the questionInput.conversioninput to questionInput.rangeinput but had NOT set up a way to send questionInput.surveyrangeinput to checkAndParseQuestionAnswerInputs(). Which would pass off questionInput to questionSyntaxFormatter with questionInput.rangeinput.

By using nested ternary statements I've made questionInput.rangeinput have the conversion and survey ranges correctly collected. This bug would make it so that it would require me to re-define the rangeinput when making any modification to a survey question (I discovered it when trying to simply update a flag). Bad!