### PR TITLE
ISSUE-200 Server: Removed requirement for an answer on a Survey.

### DIFF
--- a/server/database/datamodel.graphql
+++ b/server/database/datamodel.graphql
@@ -85,7 +85,7 @@ type Survey {
   updatedAt: DateTime!
   status: Int!
   score: Int!
-  answer: String!
+  answer: String
   detail: String
   parent: Course! @relation(name: "CourseToSurvey")
   question: Question! @relation(name: "SurveyToQuestion")

--- a/server/src/generated/prisma.graphql
+++ b/server/src/generated/prisma.graphql
@@ -1,5 +1,5 @@
 # source: http://self:4466/server/dev
-# timestamp: Wed Jul 25 2018 21:15:19 GMT-0700 (Pacific Daylight Time)
+# timestamp: Fri Sep 28 2018 11:22:34 GMT-0700 (Pacific Daylight Time)
 
 type AggregateClassroom {
   count: Int!
@@ -3718,7 +3718,7 @@ type Survey implements Node {
   updatedAt: DateTime!
   status: Int!
   score: Int!
-  answer: String!
+  answer: String
   detail: String
   parent(where: CourseWhereInput): Course!
   question(where: QuestionWhereInput): Question!
@@ -3737,7 +3737,7 @@ type SurveyConnection {
 input SurveyCreateInput {
   status: Int!
   score: Int!
-  answer: String!
+  answer: String
   detail: String
   parent: CourseCreateOneWithoutSurveysInput!
   question: QuestionCreateOneInput!
@@ -3751,7 +3751,7 @@ input SurveyCreateManyWithoutParentInput {
 input SurveyCreateWithoutParentInput {
   status: Int!
   score: Int!
-  answer: String!
+  answer: String
   detail: String
   question: QuestionCreateOneInput!
 }
@@ -3788,7 +3788,7 @@ type SurveyPreviousValues {
   updatedAt: DateTime!
   status: Int!
   score: Int!
-  answer: String!
+  answer: String
   detail: String
 }
 

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -294,7 +294,7 @@ type QaSurveyResponseObject {
   surveyId: ID!
   status: Int!
   score: Int!
-  answer: QaUnitObject!
+  answer: QaUnitObject
   detail: String
 }
 


### PR DESCRIPTION
This had to be applied to both the datamodel (the actual Survey table) and the schema (where the answer is suggested to be required in QA objects).

The server logic of qaGenerator.js is sound. In the case that the answer is null the answer data becomes null without errors or weird behavior. So no additional changes are needed to patch holes in the logic.