### PR TITLE
ISSUE-193 Client: Removing challenge state data from LocalStorage whe…

### DIFF
--- a/client/src/components/entry/Logout.js
+++ b/client/src/components/entry/Logout.js
@@ -19,6 +19,13 @@ const Logout = (props) => {
     console.log(e.message); // eslint-disable-line no-console
   }
 
+  // Clear out the challenge state (this is a precaution).
+  try {
+    utils.removeChallengeStateLocalStorage();
+  } catch (e) {
+    console.log(e.message); // eslint-disable-line no-console
+  }
+
   // Clear out the Apollo cache.
   try {
     props.client.resetStore();


### PR DESCRIPTION
…n logging out.

This is a cautious step to make sure that corrupt challenge data doesn't lock up someone's account (on a particular browser). So that if something bad happens or I have to make a breaking change (that I'm too lazy to prevent it from breaking things, which is honestly the better idea), I can tell people to simply log out and log back in if there is a problem.