### PR TITLE
ISSUE-185 Client: Made menu items (except for logout) middle-clickable.

### DIFF
--- a/client/src/components/entry/Login.js
+++ b/client/src/components/entry/Login.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Mutation, compose } from "react-apollo";
 import { Redirect } from "react-router-dom";
 import { withRouter } from "react-router";
+import { Grid } from "semantic-ui-react";
 
 import AlreadyLoggedIn from "./AlreadyLoggedIn";
 import LoginSignupForm from "./LoginSignupForm";
@@ -14,6 +15,10 @@ import {
   SIGNUP_MUTATION,
   LOGIN_MUTATION,
 } from "../../graphql/Mutations";
+
+import {
+  FLOATING_CENTER_GRID_COLUMN_WIDTH_LARGE,
+} from "../../constants";
 
 class Login extends PureComponent {
   constructor(props) {
@@ -52,12 +57,19 @@ class Login extends PureComponent {
         }}
       >
         {(login, { loading, error }) => (
-          <LoginSignupForm
-            loginPage={loginPage}
-            onSubmit={variables => login({ variables })}
-            loading={loading}
-            error={error}
-          />
+          <Grid centered>
+            <Grid.Row>
+              <Grid.Column {...FLOATING_CENTER_GRID_COLUMN_WIDTH_LARGE}>
+                <br />
+                <LoginSignupForm
+                  loginPage={loginPage}
+                  onSubmit={variables => login({ variables })}
+                  loading={loading}
+                  error={error}
+                />
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
         )}
       </Mutation>
     );

--- a/client/src/components/entry/LoginSignupForm.js
+++ b/client/src/components/entry/LoginSignupForm.js
@@ -2,13 +2,14 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import {
-  Header,
-  Segment,
-  Form,
   Container,
   Dimmer,
+  Form,
+  Header,
+  Icon,
   Loader,
   Message,
+  Segment,
 } from "semantic-ui-react";
 
 import utils from "../../utils";
@@ -17,7 +18,7 @@ import {
   PASSWORD_MINIMUM_LENGTH,
 } from "../../constants";
 
-import LoadingButton from "..//misc/LoadingButton";
+import LoadingButton from "../misc/LoadingButton";
 
 class LoginSignupForm extends Component {
   constructor(props) {
@@ -77,11 +78,12 @@ class LoginSignupForm extends Component {
 
   render() {
     return (
-      <Segment textAlign="left" >
+      <Segment textAlign="left">
         <Dimmer inverted active={this.props.loading}>
           <Loader />
         </Dimmer>
         <Header size="huge" textAlign="center">
+          <Icon name={this.props.loginPage ? "sign in" : "signup"} size="large" />
           Please {this.props.loginPage ? "login" : "sign-up"} below!
         </Header>
         <Form>
@@ -154,8 +156,9 @@ class LoginSignupForm extends Component {
         <Message attached negative>
           <Message.Header>Form Errors</Message.Header>
           <ul>
-            {this.state.formErrors.map(errorMessage =>
-              <li key={errorMessage}>{errorMessage}</li>)}
+            {this.state.formErrors.map(errorMessage => (
+              <li key={errorMessage}>{errorMessage}</li>
+            ))}
           </ul>
         </Message>
         }

--- a/client/src/components/main/MenuContentBasics.js
+++ b/client/src/components/main/MenuContentBasics.js
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 import { Menu, Icon } from "semantic-ui-react";
 
 const MenuContentBasics = props => (
   [
     <Menu.Item
       key="main"
+      as={Link}
       to="/"
       onClick={props.navigateTo}
     >
@@ -16,6 +18,7 @@ const MenuContentBasics = props => (
     props.loggedIn ?
       <Menu.Item
         key="challenge"
+        as={Link}
         to="/challenge"
         onClick={props.navigateTo}
       >
@@ -25,6 +28,7 @@ const MenuContentBasics = props => (
       </Menu.Item> : null,
     <Menu.Item
       key="subjects"
+      as={Link}
       to="/subjects"
       onClick={props.navigateTo}
     >
@@ -35,6 +39,7 @@ const MenuContentBasics = props => (
     props.loggedIn ?
       <Menu.Item
         key="profile"
+        as={Link}
         to="/user/me"
         onClick={props.navigateTo}
       >
@@ -45,6 +50,7 @@ const MenuContentBasics = props => (
     props.showAdminLink ?
       <Menu.Item
         key="admin"
+        as={Link}
         to="/admin"
         onClick={props.navigateTo}
       >

--- a/client/src/components/main/MenuContentLogin.js
+++ b/client/src/components/main/MenuContentLogin.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 import { Menu } from "semantic-ui-react";
 
 import SimpleConfirm from "../misc/SimpleConfirm";
@@ -27,6 +28,7 @@ const MenuContentLogin = props => (
     [
       <Menu.Item
         key="signup"
+        as={Link}
         to="/signup"
         onClick={props.navigateTo}
       >

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -6,6 +6,7 @@ export const CHALLENGE_STATE = "challenge-state";
 
 // Responsive Sizing
 export const FLOATING_CENTER_GRID_COLUMN_WIDTH_MEDIUM = { mobile: 16, tablet: 8, computer: 8 };
+export const FLOATING_CENTER_GRID_COLUMN_WIDTH_LARGE = { mobile: 16, tablet: 12, computer: 10 };
 export const FLOATING_CENTER_GRID_COLUMN_WIDTH_WIDE = { mobile: 16, tablet: 14, computer: 14 };
 export const FLOATING_CENTER_GRID_COLUMN_WIDTH_FULL = { mobile: 16, tablet: 16, computer: 16 };
 export const CHALLENGE_DETAILS_GRID_COLUMN_LEFT = { mobile: 5, tablet: 4, computer: 3 };


### PR DESCRIPTION
I was considering switching the Login/Signup buttons to be middle-clickable but they would lose their magic on redirecting backward to the Subjects page and I didn't want to lose that - besides, someone wouldn't be expected to middle-click it anyway...

Outside of scope... making Login component slightly prettier. Defined a new width setting "large" and use it for the Login component. Added a nice Icon to the Header component.