### PR TITLE
ISSUE-231 Client: Fixed double score counting.

### DIFF
--- a/client/src/components/challenge/complete/ChallengeCompleteDetailScores.js
+++ b/client/src/components/challenge/complete/ChallengeCompleteDetailScores.js
@@ -15,7 +15,7 @@ const ChallengeCompleteDetailScores = props => (
         <Progress
           value={(utils.minMax(
             0,
-            row.existingScore + (props.showScoreUpdate ? row.scoreChange : 0),
+            row.currentScore - (props.showScoreUpdate ? 0 : row.scoreChange),
             props.maxScore,
           ))}
           total={props.maxScore}
@@ -43,7 +43,7 @@ ChallengeCompleteDetailScores.propTypes = {
   scoreUpdates: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    existingScore: PropTypes.number.isRequired,
+    currentScore: PropTypes.number.isRequired,
     scoreChange: PropTypes.number.isRequired,
   })).isRequired,
 };

--- a/client/src/components/challenge/complete/ChallengeCompleteDetails.js
+++ b/client/src/components/challenge/complete/ChallengeCompleteDetails.js
@@ -49,7 +49,7 @@ const ChallengeCompleteDetails = props => (
                         {
                           id: row.id,
                           label: row.name,
-                          existingScore: (row.masteries.length && row.masteries[0].score) || 0,
+                          currentScore: (row.masteries.length && row.masteries[0].score) || 0,
                           scoreChange: utils.cacheGetTarget(
                             props.challengeResults.masteryscoreinput,
                             row.id,
@@ -98,7 +98,7 @@ const ChallengeCompleteDetails = props => (
                             utils.questionTextGrabber(row.question.question),
                             45,
                           ),
-                          existingScore: row.score,
+                          currentScore: row.score,
                           scoreChange: utils.cacheGetTarget(
                             props.challengeResults.surveyscoreinput,
                             row.id,


### PR DESCRIPTION
What was going on was that when submitting answers the results page wouldn't move forward until to show the scores until after the submission had been made. When that submission was complete there was a second pair of queries (one for Mastery and one for Survey) that would grab the "existing" scores. When writing this I didn't think it through. So that when the score board was shown it was grabbing the newly updated scores from the server. There isn't a race condition to worry about, the query only runs after the results have been submitted. Now instead I use the scoreChange prop and subtract it from the "current" score (I renamed it from "existing" score as it implies it is the pre-challenge score).