### PR TITLE
ISSUE-239 Client: Fixed toMetric sorting.

### DIFF
--- a/client/src/components/admin/question/QuestionListTable.js
+++ b/client/src/components/admin/question/QuestionListTable.js
@@ -29,7 +29,7 @@ class QuestionListTable extends PureComponent {
     const addressBook = {
       subject: "parent.parent.name",
       scale: "parent.scale",
-      direction: "parent.direction",
+      direction: "parent.toMetric",
       type: "type",
       status: "status",
       flags: "flags",


### PR DESCRIPTION
Spent the better portion of an hour trying to figure out some crazy in-place modification of the questionData object by modifying "parent.direction" and casting it from boolean to a number (or string) that would then be sortable. The whole thing was that I presumed that sortBy() couldn't sort boolean values. Which is utterly ridiculous in retrospect... But anyway. When things weren't working (I was thinking I was having to deal with copies vs references to different objects and how lodash iteration functions would or wouldn't allow me to update in place) I decided to just console log out questionData. There I realized that the data wasn't "parent.direction", it was "parent.toMetric". I changed that and boom, it works. Suuuuper stupid bug I wrote in the first place... 😩