### PR TITLE
ISSUE-247 Client: Added previous incorrect input hint helping.

### DIFF
--- a/client/src/components/challenge/ChallengeList.js
+++ b/client/src/components/challenge/ChallengeList.js
@@ -102,6 +102,8 @@ const ChallengeList = (props) => {
       if (CHALLENGE_CLEAR_INCORRECT_ANSWERS_ON_CORRECT &&
       currentChallengeProgress.incorrectAnswers.length) {
         // Update incorrectAnswers with null values so no longer are incorrect answers greyed-out.
+        // These are made into null values so that we don't lose the length of the array to track
+        // the number of incorrect answers.
         // Take note that that this counts on specific if/else behavior in
         // ChallengeManager.updateChallengeProgress(), so be aware of that when modifying.
         challengeProgressUpdate.incorrectAnswers =

--- a/client/src/components/challenge/ChallengePage.js
+++ b/client/src/components/challenge/ChallengePage.js
@@ -56,11 +56,11 @@ class ChallengePage extends PureComponent {
         questionModeStart: true,
         challengeId: cuid.slug(),
         selectedQuestionIds: [
-          "cjnc5d7jr007p0832lip756qg", // Written (w/ answer detail)
-          // "cjkkls86v021h0893gsthx41f", // Written (w/ media)
+          // "cjnc5d7jr007p0832lip756qg", // Written (w/ answer detail)
+          // "cjnc5d7ar004x0832ubbvemwz", // Written (w/ media)
           // "cjnc5d7ni008x08328owwcpu6", // Conversion (simple)
-          // "cjnc5d7gt006p08321j01wxe3", // Conversion (annotated)
-          // "cjnc5d7kx00850832k6z2tflg", // Conversion (annotated, from metric)
+          // "cjnc5d7fq006d0832j4kq5bjb", // Conversion (annotated)
+          "cjnc5d7kb007x0832p7ahstts", // Conversion (annotated, from metric)
           // "cjnc5d7yl00d90832r5tvircn", // Conversion (to floz)
           // "cjnc5d7hh006x0832s0ysl0t6", // Survey (note not required)
           // "cjnc5d7hs00710832zvfun2vo", // Survey (note optional)

--- a/client/src/components/challenge/main/ChallengeMain.js
+++ b/client/src/components/challenge/main/ChallengeMain.js
@@ -129,12 +129,13 @@ class ChallengeMain extends PureComponent {
         responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER) {
           // TODO - Survey re-choose support
           const { data } = qaData.answer;
+          const payloadAnswer = parseFloat(payload.answer.slice(2));
 
-          const miss = Math.abs(payload.answer - data.conversion.friendly);
+          const miss = Math.abs(payloadAnswer - data.conversion.friendly);
           if (miss < 0.1) {
             dimmerExtra = deline`
               You answer,
-              ${utils.unitWorder(payload.answer, data.toUnitWord, true)},
+              ${utils.unitWorder(payloadAnswer, data.toUnitWord, true)},
               was ${miss === 0 ? "" : "almost "}exactly right!
             `;
           } else {
@@ -142,7 +143,7 @@ class ChallengeMain extends PureComponent {
               Correct answer is
               ${utils.unitWorder(data.conversion.friendly, data.toUnitWord, true)}.
               Your answer:
-              ${utils.unitWorder(payload.answer, data.toUnitWord, true)}.
+              ${utils.unitWorder(payloadAnswer, data.toUnitWord, true)}.
             `;
           }
         }
@@ -161,12 +162,13 @@ class ChallengeMain extends PureComponent {
         responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER) {
           // TODO - Survey re-choose support
           const { data } = qaData.answer;
+          const payloadAnswer = parseFloat(payload.answer.slice(2));
 
           dimmerExtra = deline`
             The correct answer is
-            ${data.conversion.friendly > payload.answer ? "greater" : "less"}
+            ${data.conversion.friendly > payloadAnswer ? "greater" : "less"}
             than your answer: 
-            ${utils.unitWorder(payload.answer, data.toUnitWord, true)}.
+            ${utils.unitWorder(payloadAnswer, data.toUnitWord, true)}.
           `;
         }
       } else if (resolution === CHALLENGE_RESOLUTION_SURVEY_FILLED) {
@@ -272,7 +274,7 @@ ChallengeMain.propTypes = {
   qaData: QA_DATA_EVERYTHING.isRequired,
   currentQaProgress: PropTypes.shape({
     correctAnswerCount: PropTypes.number.isRequired,
-    incorrectAnswers: PropTypes.arrayOf(PropTypes.number).isRequired,
+    incorrectAnswers: PropTypes.arrayOf(PropTypes.string).isRequired,
     responseMode: PropTypes.number,
   }).isRequired,
   currentChallenge: PropTypes.shape({

--- a/client/src/components/challenge/main/response/ChallengeAnswerArea.js
+++ b/client/src/components/challenge/main/response/ChallengeAnswerArea.js
@@ -6,6 +6,8 @@ import ChallengeAnswerConversionDirect from "./conversion/ChallengeAnswerConvers
 import ChallengeAnswerConversionSlider from "./conversion/ChallengeAnswerConversionSlider";
 import ChallengeSurveyNoteInput from "./ChallengeSurveyNoteInput";
 
+import utils from "../../../../utils";
+
 import {
   QA_DATA_EVERYTHING,
 } from "../../../../propTypes";
@@ -23,6 +25,14 @@ import {
 const ChallengeAnswerArea = (props) => {
   const { currentChallenge, currentQaProgress } = props;
   const { responseMode } = props.currentQaProgress;
+
+  const incorrectAnswerHint = responseMode === CHALLENGE_RESPONSE_INPUT_DIRECT ||
+  responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER ?
+    utils.challengeIncorrectAnswerHinter(
+      props.incorrectAnswers,
+      props.qaData.answer.data.unit,
+      props.qaData.answer.data.conversion.exact,
+    ) : null;
 
   if (responseMode === CHALLENGE_RESPONSE_MULTIPLE_WRITTEN) {
     return (
@@ -52,6 +62,7 @@ const ChallengeAnswerArea = (props) => {
         updateCurrentChallengeData={props.updateCurrentChallengeData}
         inputUnit={props.qaData.answer.data.unit}
         inputtedAnswer={currentChallenge.inputData}
+        incorrectAnswerHint={incorrectAnswerHint}
       />
     );
   } else if (responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER) {
@@ -63,6 +74,7 @@ const ChallengeAnswerArea = (props) => {
         rangeMin={currentQaProgress.rangeData[0]}
         rangeMax={currentQaProgress.rangeData[1]}
         rangeStep={currentQaProgress.rangeData[2]}
+        incorrectAnswerHint={incorrectAnswerHint}
       />
     );
   } else if (responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER_SURVEY_FILLER) {
@@ -110,7 +122,7 @@ ChallengeAnswerArea.propTypes = {
     responseMode: PropTypes.number.isRequired,
   }).isRequired,
   updateCurrentChallengeData: PropTypes.func.isRequired,
-  incorrectAnswers: PropTypes.arrayOf(PropTypes.number).isRequired,
+  incorrectAnswers: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default ChallengeAnswerArea;

--- a/client/src/components/challenge/main/response/ChallengeResponse.js
+++ b/client/src/components/challenge/main/response/ChallengeResponse.js
@@ -40,9 +40,9 @@ function ChallengeResponse(props) {
     utils.t0(currentChallenge.inputData)) {
       // Multiple choice answers should be === 0 to be correct.
       if (currentChallenge.inputData === 0) {
-        props.resolveQa(CHALLENGE_RESOLUTION_CORRECT, { answer: currentChallenge.inputData });
+        props.resolveQa(CHALLENGE_RESOLUTION_CORRECT, { answer: `c_${currentChallenge.inputData}` });
       } else {
-        props.resolveQa(CHALLENGE_RESOLUTION_INCORRECT, { answer: currentChallenge.inputData });
+        props.resolveQa(CHALLENGE_RESOLUTION_INCORRECT, { answer: `c_${currentChallenge.inputData}` });
       }
     } else if ((currentQaProgress.responseMode === CHALLENGE_RESPONSE_INPUT_DIRECT ||
       currentQaProgress.responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER) &&
@@ -53,9 +53,9 @@ function ChallengeResponse(props) {
       if (!Number.isNaN(inputValue) &&
       inputValue >= props.qaData.answer.data.conversion.range.bottom.value &&
       inputValue <= props.qaData.answer.data.conversion.range.top.value) {
-        props.resolveQa(CHALLENGE_RESOLUTION_CORRECT, { answer: inputValue });
+        props.resolveQa(CHALLENGE_RESOLUTION_CORRECT, { answer: `i_${inputValue}` });
       } else {
-        props.resolveQa(CHALLENGE_RESOLUTION_INCORRECT, { answer: inputValue });
+        props.resolveQa(CHALLENGE_RESOLUTION_INCORRECT, { answer: `i_${inputValue}` });
       }
     } else if (currentQaProgress.responseMode === CHALLENGE_RESPONSE_INPUT_SLIDER_SURVEY_FILLER) {
       // Filling out a survey is different. The inputData is an object.
@@ -118,7 +118,7 @@ ChallengeResponse.propTypes = {
     inputData: PropTypes.any,
   }).isRequired,
   currentQaProgress: PropTypes.shape({
-    incorrectAnswers: PropTypes.arrayOf(PropTypes.number).isRequired,
+    incorrectAnswers: PropTypes.arrayOf(PropTypes.string).isRequired,
     responseMode: PropTypes.number,
   }).isRequired,
   challengeCompletion: PropTypes.shape({

--- a/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirect.js
+++ b/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirect.js
@@ -20,6 +20,7 @@ const ChallengeAnswerConversionDirect = (props) => {
         inputUnit={props.inputUnit}
         inputValue={props.inputtedAnswer || ""}
         placeholder="..."
+        incorrectAnswerHint={props.incorrectAnswerHint}
       />
     );
   } else {
@@ -29,6 +30,7 @@ const ChallengeAnswerConversionDirect = (props) => {
         inputUnit={props.inputUnit}
         inputValue={props.inputtedAnswer || ""}
         placeholder="..."
+        incorrectAnswerHint={props.incorrectAnswerHint}
       />
     );
   }
@@ -38,10 +40,12 @@ ChallengeAnswerConversionDirect.propTypes = {
   updateCurrentChallengeData: PropTypes.func.isRequired,
   inputUnit: PropTypes.string.isRequired,
   inputtedAnswer: PropTypes.string,
+  incorrectAnswerHint: PropTypes.string,
 };
 
 ChallengeAnswerConversionDirect.defaultProps = {
   inputtedAnswer: null,
+  incorrectAnswerHint: null,
 };
 
 export default ChallengeAnswerConversionDirect;

--- a/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirectInput.js
+++ b/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirectInput.js
@@ -62,6 +62,13 @@ const ChallengeAnswerConversionDirectInput = (props) => {
           />
         </Grid.Column>
       </Grid.Row>
+      {props.incorrectAnswerHint &&
+      <Grid.Row>
+        <Grid.Column>
+          <p>{props.incorrectAnswerHint}</p>
+        </Grid.Column>
+      </Grid.Row>
+      }
       <Grid.Row>
         <Grid.Column {...CHALLENGE_KEYPAD_COLUMN_WIDTH}>
           <ChallengeAnswerConversionDirectKeypad
@@ -80,11 +87,13 @@ ChallengeAnswerConversionDirectInput.propTypes = {
   inputUnit: PropTypes.string.isRequired,
   inputValue: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
+  incorrectAnswerHint: PropTypes.string,
   inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 ChallengeAnswerConversionDirectInput.defaultProps = {
   inputProps: null,
+  incorrectAnswerHint: null,
 };
 
 export default ChallengeAnswerConversionDirectInput;

--- a/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirectInputSplit.js
+++ b/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionDirectInputSplit.js
@@ -125,6 +125,13 @@ class ChallengeAnswerConversionDirectInputSplit extends PureComponent {
             />
           </Grid.Column>
         </Grid.Row>
+        {this.props.incorrectAnswerHint &&
+          <Grid.Row>
+            <Grid.Column>
+              <p>{this.props.incorrectAnswerHint}</p>
+            </Grid.Column>
+          </Grid.Row>
+        }
         <Grid.Row>
           <Grid.Column {...CHALLENGE_KEYPAD_COLUMN_WIDTH}>
             <ChallengeAnswerConversionDirectKeypad
@@ -147,11 +154,13 @@ ChallengeAnswerConversionDirectInputSplit.propTypes = {
   inputUnit: PropTypes.string.isRequired,
   inputValue: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
+  incorrectAnswerHint: PropTypes.string,
   inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 ChallengeAnswerConversionDirectInputSplit.defaultProps = {
   inputProps: null,
+  incorrectAnswerHint: null,
 };
 
 export default ChallengeAnswerConversionDirectInputSplit;

--- a/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionSlider.js
+++ b/client/src/components/challenge/main/response/conversion/ChallengeAnswerConversionSlider.js
@@ -38,6 +38,13 @@ const ChallengeAnswerConversionSlider = (props) => {
           />
         </Grid.Column>
       </Grid.Row>
+      {props.incorrectAnswerHint &&
+        <Grid.Row>
+          <Grid.Column>
+            <p>{props.incorrectAnswerHint}</p>
+          </Grid.Column>
+        </Grid.Row>
+      }
     </Grid>
   );
 };
@@ -50,11 +57,13 @@ ChallengeAnswerConversionSlider.propTypes = {
   rangeMax: PropTypes.number.isRequired,
   rangeStep: PropTypes.number.isRequired,
   surveyAnswerMode: PropTypes.bool,
+  incorrectAnswerHint: PropTypes.string,
 };
 
 ChallengeAnswerConversionSlider.defaultProps = {
   inputtedAnswer: null,
   surveyAnswerMode: false,
+  incorrectAnswerHint: null,
 };
 
 export default ChallengeAnswerConversionSlider;

--- a/client/src/components/challenge/main/response/multipleChoice/ChallengeAnswerMultipleChoice.js
+++ b/client/src/components/challenge/main/response/multipleChoice/ChallengeAnswerMultipleChoice.js
@@ -33,7 +33,7 @@ const ChallengeAnswerMultipleChoice = (props) => {
       key={`choice_${choiceNumber}`}
       number={choiceNumber}
       text={makeText(props.choices[choiceNumber])}
-      wrong={props.incorrectAnswers.includes(choiceNumber)}
+      wrong={props.incorrectAnswers.includes(`c_${choiceNumber}`)}
       selected={props.selectedAnswer === choiceNumber}
       handleSelect={handleAnswerSelect}
     />
@@ -75,7 +75,7 @@ ChallengeAnswerMultipleChoice.propTypes = {
   }).isRequired).isRequired,
   updateCurrentChallengeData: PropTypes.func.isRequired,
   choicesSelected: PropTypes.arrayOf(PropTypes.number), // This will temporarily be undefined.
-  incorrectAnswers: PropTypes.arrayOf(PropTypes.number).isRequired,
+  incorrectAnswers: PropTypes.arrayOf(PropTypes.string).isRequired,
   selectedAnswer: PropTypes.number,
 };
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -2,6 +2,7 @@ import md5 from "md5";
 import jwt_decode from "jwt-decode";  // eslint-disable-line camelcase
 import isEmail from "validator/lib/isEmail";
 import isDecimal from "validator/lib/isDecimal";
+import findLast from "lodash/findLast";
 import mergeWith from "lodash/mergeWith";
 import random from "lodash/random";
 import range from "lodash/range";
@@ -772,6 +773,34 @@ const scoreProgressColor = (currentScore, maxScore) => {
 
 
 /**
+ * Generates the incorrect answer hint helper for slider and direct input.
+ * @param incorrectAnswers
+ * @param inputUnit
+ * @param correctAnswer
+ * @returns {*}
+ */
+const challengeIncorrectAnswerHinter = (incorrectAnswers, inputUnit, correctAnswer) => {
+  if (incorrectAnswers.length) {
+    const lastInputAnswer = findLast(incorrectAnswers, (answer) => {
+      if (typeof answer === "string") {
+        return answer.includes("i_");
+      }
+      return false;
+    });
+
+    if (lastInputAnswer) {
+      const lastAnswerNumber = parseFloat(lastInputAnswer.slice(2));
+      return deline`
+      Hint: Your previous input,
+      ${unitWorder(lastAnswerNumber, UNIT_WORDS[inputUnit], true)},
+      was too ${lastAnswerNumber > correctAnswer ? "high" : "low"}.`;
+    }
+  }
+  return null;
+};
+
+
+/**
  * Super simple function. You put in your value and your fromUnitWord or toUnitWord object and get
  * the proper string in return.
  * Ex:
@@ -1317,6 +1346,7 @@ export default {
   stringTruncator,
   isEmptyRecursive,
   scoreProgressColor,
+  challengeIncorrectAnswerHinter,
   unitWorder,
   unitReadabilityHelper,
   rangeWorder,


### PR DESCRIPTION
Hooo boy. Poor planning here but it's working. The worst thing I had to do was to separate the differences between multiple-choice answers (numbered 0-8) and user-input answers (any number). To differentiate them I added prefixes "c_" for multiple Choice, and "i_" for direct Input so that the hinter would not mistakenly say that the previous wrong answer was 2 (a multiple choice answer).

Now, I wish I had written the whole system to instead record incorrect conversion multiple choice answers' values instead of the choice number. Something for the future I suppose...